### PR TITLE
GET operation ignored 'type' query parameter

### DIFF
--- a/crud-file-server.js
+++ b/crud-file-server.js
@@ -128,7 +128,7 @@ exports.handleRequest = function(vpath, path, req, res, readOnly, logHeadRequest
 														}
 													});
 												} else {
-													if(query.dir == 'json') {
+													if(query.type == 'json') {
 														res.setHeader('Content-Type', 'application/json');
 														res.write(JSON.stringify(results)); 
 														res.end();


### PR DESCRIPTION
example: GET localhost/newDir?type=json, 'type' was ignored the the response type was always 'html', not 'json'.
